### PR TITLE
Add setup script for fedora

### DIFF
--- a/setup/setup-fedora.sh
+++ b/setup/setup-fedora.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# find out where this is executing and cd to the project root
+cd $(dirname $(realpath $0))
+cd ..
+
+# install packages
+sudo dnf upgrade
+sudo dnf install --refresh nasm gcc binutils qemu git make mtools curl unzip e2fsprogs
+# (ovmf is a dependency of qemu)
+
+# install gnu-uefi headers
+rm -rf gnu-efi
+git clone https://www.github.com/somecollagist/gnu-efi-3.0.15
+mv gnu-efi-3.0.15 gnu-efi
+cd gnu-efi
+make
+cd ..
+
+# OVMF provides a way of booting via UEFI for qemu, so copy it
+cp -r /usr/share/edk2/ovmf ./OVMF && \
+mv ./OVMF/OVMF_CODE.fd ./OVMF/OVMF.fd


### PR DESCRIPTION
Didn't need to fiddle with ownership for fedora, just a copy does the trick as far as I can tell. Needed to rename the file to match what it was called in arch.
`dnf upgrade` before to avoid package conflicts. Packages mostly had the same name, only ovmf, which is a dependency of qemu, was called edk2-ovmf.
Currently the dnfs will prompt for confirmation, you can add -y to them if you don't want to have confirmation