### PR TITLE
move gnu-efi dependency to makefile and optimize efi build process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,12 +22,15 @@ LOEXT_MNT		:= /mnt/$(OS)_ext
 
 # .SILENT: prebuild build clean
 
-all: prebuild build
+all: clean prebuild build
 
-prebuild:
+clean:
 	clear
 	rm -rf $(BIN) $(BOOTBIN) $(IMG)
 	mkdir $(BIN) $(BOOTBIN)
+
+prebuild:
+	git clone https://www.github.com/somecollagist/gnu-efi-3.0.15 gnu-efi && make -C gnu-efi
 
 build:
 	make -C $(BOOTSRC)
@@ -36,7 +39,7 @@ build:
 	dd if=/dev/zero of=$(IMG) bs=1M count=256
 	sudo gdisk $(IMG) < $(ROOT)/gdiskcmds
 	sudo losetup -P $(LODEV) $(IMG)
-	
+
 	sudo mformat -i $(LOEFI) -f 2880 ::
 	sudo mkfs.ext2 $(LOEXT)
 
@@ -48,7 +51,7 @@ build:
 	sudo cp $(BOOTBIN)/BOOTX64.EFI $(LOEFI_MNT)/EFI/BOOT/BOOTX64.EFI
 	sudo cp startup.nsh $(LOEFI_MNT)/startup.nsh
 	sudo cp $(BIN)/kernel.elf $(LOEFI_MNT)/kernel.elf
-	
+
 	sudo umount $(LOEFI_MNT)
 	sudo umount $(LOEXT_MNT)
 	sudo rm -rf $(LOEFI_MNT) $(LOEXT_MNT)
@@ -64,4 +67,4 @@ run:
 		-usb $(IMG) \
 		-vga std \
 		-m 256M
-		
+

--- a/setup/setup-arch.sh
+++ b/setup/setup-arch.sh
@@ -8,14 +8,6 @@ cd ..
 sudo pacman -Syy
 sudo pacman -S nasm gcc binutils qemu-desktop ovmf git make dosfstools curl unzip e2fsprogs gdisk
 
-# install gnu-uefi headers
-rm -rf gnu-efi
-git clone https://www.github.com/somecollagist/gnu-efi-3.0.15
-mv gnu-efi-3.0.15 gnu-efi
-cd gnu-efi
-make
-cd ..
-
 # OVMF provides a way of booting via UEFI for qemu, so copy it and make us the owner
 sudo cp -r /usr/share/ovmf/x64 ./OVMF
 sudo chown -R --reference=README.md ./OVMF

--- a/setup/setup-fedora.sh
+++ b/setup/setup-fedora.sh
@@ -11,14 +11,6 @@ sudo dnf upgrade
 sudo dnf install --refresh nasm gcc binutils qemu git make dosfstools curl unzip e2fsprogs gdisk
 # (ovmf is a dependency of qemu)
 
-# install gnu-uefi headers
-rm -rf gnu-efi
-git clone https://www.github.com/somecollagist/gnu-efi-3.0.15
-mv gnu-efi-3.0.15 gnu-efi
-cd gnu-efi
-make
-cd ..
-
 # OVMF provides a way of booting via UEFI for qemu, so copy it
 cp -r /usr/share/edk2/ovmf ./OVMF && \
 mv ./OVMF/OVMF_CODE.fd ./OVMF/OVMF.fd


### PR DESCRIPTION
Pretty simple change. Breaks Makefile into individual segments that the user can invoke at will, and moves gnu-efi headers to the Makefile to avoid running the setup scripts repeatedly if efi files are somehow removed.

Also cleans up `gnu-efi` directory on 'make clean`