### PR TITLE
added debugging symbols, debugrun makefile target, memset function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,4 +64,13 @@ run:
 		-usb $(IMG) \
 		-vga std \
 		-m 256M
-		
+
+debugrun:
+	qemu-system-x86_64 \
+		-L OVMF/ \
+		-pflash OVMF/OVMF.fd \
+		-net none \
+		-usb $(IMG) \
+		-vga std \
+		-m 256M \
+		-s -S

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Contributions are very welcome! I'm just a man, and my time isn't plentiful in n
 ### Development
 To start contributing, run `setup/setup-(os).sh` as described in [Running Derecho](#running-derecho). From there, write your changes and run `make` to compile the source code, or `make run` to run the compiled OS in QEMU.
 
+In order to debug, you can run `make debugrun` in the terminal which will start qemu, and give you a chance to attach a debugger like GDB to QEMU. In order to attach a debugger to QEMU (this uses GDB), you need to first run `gdb` in another terminal. Then you need to run `file path/to/kernel.elf` to get the debugging symbols. The kernel.elf is located in (project root)/bin/kernel.elf. After that, run `target remote localhost:1234` to attach GDB to QEMU since QEMU uses port 1234. Then set a breakpoint using `break functionname` or `break filename:line`. Then you need to run `continue` and then you can use `step` to step through code after the breakpoint is hit. Anyway, I'm not going to teach you how to use GDB here, you need to learn that yourself.
+
 Development is pretty open-ended so do whatever you want, but there's a few things to adhere to:
  - The development language is British English. If you don't know what that looks like, it's the code I write.
  - Indent using tabs (equivalent to four spaces).

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,11 +1,13 @@
 CFLG := -I$(GNUEFI)/inc -I$(GNUEFI)/lib -I$(ROOT) \
+		-g \
 		-lgnuefi -lefi \
 		-ffreestanding -fshort-wchar -fno-stack-protector \
+		-mno-red-zone \
 		$(CWARNS)
 CSRC := $(shell find $(SRC) -name "*.c")
 CTAR := $(patsubst $(SRC)/%,$(BIN)/%,$(patsubst %.c,%.o,$(CSRC)))
 
-AFLG := -f elf64
+AFLG := -g -f elf64
 ASRC := $(shell find $(SRC) -name "*.asm")
 ATAR := $(patsubst $(SRC)/%,$(BIN)/%,$(patsubst %.asm,%.o,$(ASRC)))
 

--- a/src/utils/memory.c
+++ b/src/utils/memory.c
@@ -10,6 +10,14 @@ void strcpy(char* src, char* dst)
 	}
 }
 
+void memset(void* dst, int8_t value, size_t count)
+{
+	int8_t* d = dst;
+
+	for (size_t i = 0; i < count; i++)
+		*d++ = value;
+}
+
 void memcpy(const void* restrict src, void* restrict dst, size_t count)
 {
 	const uint8_t* s = src;

--- a/src/utils/memory.h
+++ b/src/utils/memory.h
@@ -7,6 +7,12 @@
 /// @param dst Destination memory location (place for data to be copied to)
 void strcpy(char* src, char* dst);
 
+/// @brief Sets data at a memory location to a specified value
+/// @param dst Destination memory location
+/// @param value The value you want to set the memory to
+/// @param count The number of bytes you want to set
+void memset(void* dst, int8_t value, size_t count);
+
 /// @brief Copies memory from one location to another, this does not handle overlapping memory regions
 /// @param src Source memory location (data to be copied)
 /// @param dst Destination memory location (place for data to be copied to)


### PR DESCRIPTION
I added a debugrun makefile target in the root makefile, which gives you a chance to attach a debugger to qemu, I also added some documentation on how to attach GDB to qemu.

Having the debugrun target is nice, but you also need debugging symbols to make it useful, so I made changes to the kernel makefile, where i added the -g flag to the gcc and nasm flags to create the debugging symbols. I also added the no red zone flag in the gcc flags in the kernel makefile, as not having it will probably cause problems with nested interrupts

I also added a memset function since I forgot that last time I made a PR